### PR TITLE
Docker/MCPサーバ対応

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+test/logs
+test/reports
+*.md
+.git
+.gitignore
+playwright-report

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Dockerfile for M5Stack AI FAE MCP (Playwright + MCPサーバ)
+FROM mcr.microsoft.com/playwright:v1.51.1-jammy
+
+# 作業ディレクトリ設定
+WORKDIR /app
+
+# package.json, package-lock.json をコピーして依存解決を高速化
+COPY package*.json ./
+
+# 依存インストール
+RUN npm install && \
+    npx playwright install chromium
+
+# プロジェクト全体をコピー
+COPY . .
+
+# MCPサーバをデフォルトで起動
+CMD ["node", "mcp-server.js"]
+
+# ポート公開
+EXPOSE 3000

--- a/doc/m5ai_mcp.md
+++ b/doc/m5ai_mcp.md
@@ -54,10 +54,49 @@ M5Stack_AI_FAE_MCP/
 
 ### 実行方法
 
-通常のテスト実行（ブラウザ表示あり）:
+#### 1. Playwrightテストとして実行（従来通り）
 ```bash
 npm test
 ```
+
+#### 2. MCPサーバ（APIサーバ）として利用
+
+`mcp-server.js` を起動することで、外部からHTTP経由でm5stack chatbotに質問し、AI回答を取得できます。
+
+**サーバ起動（ローカル）:**
+```bash
+node mcp-server.js
+```
+
+**サーバ起動（Docker）:**
+```bash
+docker build -t m5ai-mcp .
+docker run -p 3000:3000 m5ai-mcp
+```
+
+**APIエンドポイント:**
+- `POST /ask`  
+  リクエストボディ：`{ "question": "質問内容" }`
+  
+  レスポンス例：
+  ```json
+  {
+    "question": "AtomS3 LiteにGPSモジュールを接続する方法を教えてください",
+    "answer": "（AIの回答テキスト）",
+    "html": "（回答HTML）"
+  }
+  ```
+
+**curl例:**
+```bash
+curl -X POST http://localhost:3000/ask -H "Content-Type: application/json" -d '{"question": "AtomS3 LiteにGPSモジュールを接続する方法を教えてください"}'
+```
+
+#### APIサーバの仕組み
+- ExpressベースのサーバがHTTPリクエストを受け付け
+- Playwrightでm5stack chatbotに実際にアクセス・質問を送信
+- 回答が完全に表示されるまで「考え中...」インジケータを監視し、AI回答を取得
+- 結果をJSONで返却
 
 ブラウザを表示してテスト実行（明示的に指定）:
 ```bash

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -1,0 +1,86 @@
+// MCPサーバ: m5stack chatbotに問い合わせるAPIサーバ
+const express = require('express');
+const { chromium } = require('playwright');
+const { getLatestAIResponse } = require('./test/utils/m5ai-helper');
+
+const app = express();
+app.use(express.json());
+
+// POST /ask { question: "..." }
+app.post('/ask', async (req, res) => {
+  const question = req.body.question;
+  if (!question || typeof question !== 'string') {
+    return res.status(400).json({ error: 'question is required' });
+  }
+  let browser;
+  try {
+    browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({
+      locale: 'ja-JP',
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      geolocation: { longitude: 139.7671, latitude: 35.6812 },
+      permissions: ['geolocation'],
+      timezoneId: 'Asia/Tokyo',
+      viewport: { width: 1280, height: 720 }
+    });
+    const page = await context.newPage();
+    await page.goto('https://chat.m5stack.com/', { timeout: 60000 });
+    await page.waitForLoadState('networkidle');
+
+    // テキストエリアに質問を入力
+    const textareaSelectors = [
+      'textarea[placeholder="Enterキーで送信（Shift+Enterで改行）"]',
+      'textarea[placeholder="Send a message"]',
+      '.chat-input textarea',
+      'textarea'
+    ];
+    let inputSuccess = false;
+    for (const selector of textareaSelectors) {
+      try {
+        await page.fill(selector, question);
+        inputSuccess = true;
+        break;
+      } catch (e) {}
+    }
+    if (!inputSuccess) {
+      throw new Error('質問入力に失敗しました');
+    }
+    // Enterキーで送信
+    await page.keyboard.press('Enter');
+
+    // 「考え中...」インジケータの表示を待機（最大10秒）
+    try {
+      await page.waitForSelector('.thinking-bar', { timeout: 10000 });
+    } catch (e) {}
+
+    // 「考え中...」が消えるまで待機（最大90秒）
+    try {
+      await page.waitForFunction(() => {
+        const bar = document.querySelector('.thinking-bar');
+        return !bar || bar.style.display === 'none' || bar.offsetParent === null;
+      }, { timeout: 90000 });
+    } catch (e) {}
+
+    // 回答が完全に表示されるまで追加で待機（5秒）
+    await page.waitForTimeout(5000);
+
+    // 回答取得
+    const response = await getLatestAIResponse(page);
+
+    res.json({
+      question,
+      answer: response?.text || '',
+      html: response?.html || ''
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  } finally {
+    if (browser) await browser.close();
+  }
+});
+
+// サーバ起動
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`MCPサーバが起動しました: http://localhost:${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "playwright:install-deps": "npx playwright install-deps chromium"
   },
   "dependencies": {
+    "express": "^5.1.0",
     "playwright": "^1.51.1",
     "rimraf": "^5.0.5"
   },


### PR DESCRIPTION
## 変更内容
- MCPサーバ（APIサーバ）の実装: `mcp-server.js`
- Docker対応: `Dockerfile`・`.dockerignore`追加
- ドキュメント更新: `doc/m5ai_mcp.md`にDocker運用手順追記

## 機能
- Docker環境でMCPサーバ(API)を簡単に運用可能
- ローカル/外部サーバどちらでもPlaywright自動化APIを利用できます
- `/ask`エンドポイントでm5stack chatbotに問い合わせ可能

## 使い方
```bash
# ローカル起動
node mcp-server.js

# Docker起動
docker build -t m5ai-mcp .
docker run -p 3000:3000 m5ai-mcp

# API利用例
curl -X POST http://localhost:3000/ask -H "Content-Type: application/json" -d '{"question": "AtomS3 LiteにGPSモジュールを接続する方法を教えてください"}'
```

詳細は`doc/m5ai_mcp.md`を参照ください。